### PR TITLE
feat: Add GitHub Actions workflow for Angular GitHub Pages deployment

### DIFF
--- a/.github/workflows/angular-gh-pages.yml
+++ b/.github/workflows/angular-gh-pages.yml
@@ -1,8 +1,8 @@
-# Sample workflow for building and deploying a Jekyll site to GitHub Pages
-name: Deploy Jekyll with GitHub Pages dependencies preinstalled
+# Workflow for building and deploying an Angular app to GitHub Pages
+name: Deploy Angular app to GitHub Pages
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on pushes targeting the master branch
   push:
     branches: ["master"]
 
@@ -22,38 +22,26 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build job
-  build:
+  deploy:
     runs-on: ubuntu-latest
+    # Steps will be added in the next plan step
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
-        with:
-          source: ./
-          destination: ./_site
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20.x'  # Use the Node.js version you need
+          node-version: '20.x'
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm i --legacy-peer-deps
+        run: npm ci
 
       - name: Build Angular app
-        run: npm run build -- --configuration=production --base-href=/angular-material-components/
+        run: npm run build:ci
         env:
           NODE_OPTIONS: --openssl-legacy-provider
-
-      - name: Verify build output
-        run: ls -la dist/angular-material-components/browser/
 
       - name: Setup Pages
         uses: actions/configure-pages@v5
@@ -61,17 +49,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: 'dist/angular-material-components/browser'
-          name: deployment
+          path: 'docs' # Ensure this uploads the 'docs' folder
 
-  # Deployment job
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
I've added a new workflow file `.github/workflows/angular-gh-pages.yml` to automatically build and deploy your Angular application to GitHub Pages.

Key features of the new workflow:
- Triggered on push to `master` or manually via `workflow_dispatch`.
- Uses Node.js 20.x.
- Installs dependencies with `npm ci`.
- Builds the application using the `build:ci` script from `package.json`, which correctly outputs to the `docs` directory and sets the necessary `base-href`.
- Deploys the contents of the `docs` directory to GitHub Pages.

This replaces a previous, potentially misconfigured, Jekyll-based workflow. The old file `.github/workflows/jekyll-gh-pages.yml` has been removed.